### PR TITLE
Added clarification to Temporary workaround

### DIFF
--- a/help/troubleshooting/storefront/customers-get-logged-out-or-lose-cart-content-on-magento-storefront.md
+++ b/help/troubleshooting/storefront/customers-get-logged-out-or-lose-cart-content-on-magento-storefront.md
@@ -39,7 +39,7 @@ To solve the issue, contact the third-party service provider and request their d
 
 ### Temporary workaround
 
-To make your integration work while developers of the third-party service provider resolve the issue, you can set `SameSite` value to *None*. This can be done by configuring headers in Nginx or configuring this parameter via HTTP headers.
+To make your integration work while developers of the third-party service provider resolve the issue, you can set `SameSite` value to *None*. This can be done by configuring headers in Nginx or configuring this parameter via HTTP headers. Configuring headers in Nginx doesn't apply for Adobe Commerce on cloud. For Adobe Commerce you can use a plugin for Magento/Framework/Stdlib/Cookie/CookieMetadata
 
 >[!WARNING]
 >


### PR DESCRIPTION
Adobe cloud does not allow to configure HTTP headers via Nginx configuration