### PR TITLE
Fix 404 error

### DIFF
--- a/help/how-to/general/log-locations-directories-for-pro-plan-integration-staging-production.md
+++ b/help/how-to/general/log-locations-directories-for-pro-plan-integration-staging-production.md
@@ -1,8 +1,9 @@
 ---
 title: 'Log locations (directories) for Pro plan: Integration, Staging, Production'
-description: Please refer to the [Log locations](https://devdocs.magento.com/guides/v2.2/cloud/project/log-locations.html) in our developer documentation for information about logs location for Adobe Commerce on cloud infrastructure.
+description: See [View and manage logs](https://experienceleague.adobe.com/docs/commerce-cloud-service/user-guide/develop/test/log-locations.html) in the *Commerce on Cloud Infrastructure Guide* to learn where to find build and deploy, application, and service logs for your project.
+
 exl-id: daa79b73-68c2-4c89-bf5e-51c105762774
 ---
 # Log locations (directories) for Pro plan: Integration, Staging, Production
 
-Please refer to the [Log locations](https://devdocs.magento.com/guides/v2.2/cloud/project/log-locations.html) in our developer documentation for information about logs location for Adobe Commerce on cloud infrastructure.
+See [View and manage logs](https://experienceleague.adobe.com/docs/commerce-cloud-service/user-guide/develop/test/log-locations.html) in the *Commerce on Cloud Infrastructure Guide* to learn where to find the build and deploy, application, and service logs for Adobe Commerce projects deployed on cloud infrastructure.


### PR DESCRIPTION
Updated the link to the Log locations documentation for Adobe Commerce on cloud infrastructure projects to fix a 404 error.