### PR TITLE
Update Disk Space Breakdown command to work on Cloud Servers

### DIFF
--- a/help/troubleshooting/miscellaneous/safely-delete-files-when-out-of-disk-space-adobe-commerce-on-our-cloud-architecture.md
+++ b/help/troubleshooting/miscellaneous/safely-delete-files-when-out-of-disk-space-adobe-commerce-on-our-cloud-architecture.md
@@ -35,9 +35,9 @@ To locate the largest files that might be good candidates for clearing, run the 
 
 ```bash
 FS='/data/exports';NUMRESULTS=20;resize;clear; echo "Please find below the Largest Directories and Files:";date;df -h $FS; echo "Largest Directories:";du -x /app/*/ 2>/dev/null| sort -rnk1| head -n $NUMRESULTS| awk '
-{printf "%d MB %s\n",\ $1/1024,$2}
+{printf "%d MB %s\n", $1/1024,$2}
 ';echo "Largest Files:"; nice -n 19 find /app/*/ -mount -type f -ls 2>/dev/null| sort -rnk7| head -n $NUMRESULTS|awk '
-{printf "%d MB\t%s\n",\ ($7/1024)/1024,$NF}
+{printf "%d MB\t%s\n", ($7/1024)/1024,$NF}
 '; echo "Please use the above information to clear any unwanted data from the server, it is important this is done as soon as possible to ensure your server stays functional.";
 ```
 


### PR DESCRIPTION
**Goal**
Update the command in the documentation to run on cloud servers

**Current Issue**
Running the command linked in the docs throws the following errors on Cloud environments:
```
Please find below the Largest Directories and Files:
Fri Mar 24 15:03:25 UTC 2023
Filesystem      Size  Used Avail Use% Mounted on
/dev/nvme1n1     84G   69G   15G  83% /data/exports
Largest Directories:
awk: cmd. line:2: {printf "%d MB %s\n",\ $1/1024,$2}
awk: cmd. line:2:                      ^ backslash not last character on line
awk: cmd. line:2: {printf "%d MB %s\n",\ $1/1024,$2}
awk: cmd. line:2:                      ^ syntax error
Largest Files:
awk: cmd. line:2: {printf "%d MB\t%s\n",\ ($7/1024)/1024,$NF}
awk: cmd. line:2:                       ^ backslash not last character on line
awk: cmd. line:2: {printf "%d MB\t%s\n",\ ($7/1024)/1024,$NF}
awk: cmd. line:2:                       ^ syntax error
Please use the above information to clear any unwanted data from the server, it is important this is done as soon as possible to ensure your server stays functional.
```

**Solution breakdown**
The issue with the current command is that there are unnecessary backslashes in the awk commands. By removing the unnecessary backslashes, the command should now work as expected.

**Solution**
```
FS='/data/exports';NUMRESULTS=20;resize;clear; echo "Please find below the Largest Directories and Files:";date;df -h $FS; echo "Largest Directories:";du -x /app/*/ 2>/dev/null| sort -rnk1| head -n $NUMRESULTS| awk '
{printf "%d MB %s\n", $1/1024,$2}
';echo "Largest Files:"; nice -n 19 find /app/*/ -mount -type f -ls 2>/dev/null| sort -rnk7| head -n $NUMRESULTS|awk '
{printf "%d MB\t%s\n", ($7/1024)/1024,$NF}
'; echo "Please use the above information to clear any unwanted data from the server, it is important this is done as soon as possible to ensure your server stays functional.";
```
