### PR TITLE
Update security-update-available-for-adobe-commerce-apsb24-40-revised…

### DIFF
--- a/help/troubleshooting/known-issues-patches-attached/security-update-available-for-adobe-commerce-apsb24-40-revised-to-include-isolated-patch-for-cve-2024-34102.md
+++ b/help/troubleshooting/known-issues-patches-attached/security-update-available-for-adobe-commerce-apsb24-40-revised-to-include-isolated-patch-for-cve-2024-34102.md
@@ -87,7 +87,11 @@ To help resolve the vulnerability for the affected products and versions, you mu
 
 Use the following attached patches, depending on your Adobe Commerce/Magento Open Source version:
 
-### For version 2.4.7, 2.4.7-p1:
+### For version 2.4.7-p1:
+
+* [AC-12485_Hotfix_COMPOSER_patch.zip](assets/AC-12485_Hotfix_COMPOSER_patch.zip)
+
+### For version 2.4.7:
 
 * [VULN-27015-2.4.7x_v2_COMPOSER_patch.zip](assets/VULN-27015-2.4.7x_v2_COMPOSER_patch.zip)
 


### PR DESCRIPTION
…-to-include-isolated-patch-for-cve-2024-34102.md

The VULN-27015 patch can't be applied to 2.4.7-p1

It fails because changes to all files except SecretBasedJwksFactory.php do not apply (they are already included in 2.4.7-p1).