### PR TITLE
Fix a documentation typo

### DIFF
--- a/help/troubleshooting/miscellaneous/live-search-catalog-data-sync.md
+++ b/help/troubleshooting/miscellaneous/live-search-catalog-data-sync.md
@@ -140,7 +140,7 @@ bin/magento saas:resync --feed productattributes
 Run the following commands to resync the feeds:
 
 ```
-bin/magento saas:resync --feed productattributes --cleaup-feed
+bin/magento saas:resync --feed productattributes --cleanup-feed
 bin/magento saas:resync --feed products --cleanup-feed
 bin/magento saas:resync --feed scopesCustomerGroup --cleanup-feed
 bin/magento saas:resync --feed scopesWebsite --cleanup-feed


### PR DESCRIPTION
Changes typo `--cleaup-feed` to proper option `--cleanup-feed`