### PR TITLE
Test: Troubleshooting article – Falling back to Elasticsearch7 when OpenSearch is set as the search engine in Adobe Commerce

### DIFF
--- a/help/how-to/general/falling-back-to-elasticsearch7.md
+++ b/help/how-to/general/falling-back-to-elasticsearch7.md
@@ -1,3 +1,7 @@
+---
+description: Learn how to fix Adobe Commerce reverting to Elasticsearch7 when OpenSearch isn’t recognized as a search engine.
+---
+
 # Falling back to Elasticsearch7 when OpenSearch is set as the search engine in Adobe Commerce
 
 This article explains how to resolve the issue where Adobe Commerce reverts to **Elasticsearch7** when **OpenSearch** is set as the **search engine**.

--- a/help/how-to/general/falling-back-to-elasticsearch7.md
+++ b/help/how-to/general/falling-back-to-elasticsearch7.md
@@ -1,0 +1,1 @@
+# Falling back to Elasticsearch7 when OpenSearch is set as the search engine in Adobe Commerce

--- a/help/how-to/general/falling-back-to-elasticsearch7.md
+++ b/help/how-to/general/falling-back-to-elasticsearch7.md
@@ -1,39 +1,48 @@
 ---
-description: Learn how to fix Adobe Commerce reverting to Elasticsearch7 when OpenSearch isn’t recognized as a search engine.
+description: Learn to fix Adobe Commerce reverting to Elasticsearch7 when OpenSearch isn’t recognized as a search engine.
 ---
 
 # Falling back to Elasticsearch7 when OpenSearch is set as the search engine in Adobe Commerce
 
-This article explains how to resolve the issue where Adobe Commerce reverts to **Elasticsearch7** when **OpenSearch** is set as the **search engine**.
+This article explains how to resolve the issue where Adobe Commerce reverts to **Elasticsearch7** when **OpenSearch** is set as the search engine.
 
-## Affected versions
+### Affected versions
 
 Adobe Commerce on cloud 2.4.4 - 2.4.5
 
 >**NOTE**  
 >OpenSearch is available as a search engine starting from Adobe Commerce 2.4.6.
 >
-## Issue
+### Issue
 
-You have set your **search engine** to **OpenSearch**, but the system shows following error in the `var/log/support_report.log` file:
+You have set your search engine to **OpenSearch**, but the system shows following error in the `var/log/support_report.log` file:
 
 ```
 [2024-04-04T00:27:41.212916+00:00] report.ERROR: opensearch search engine doesn't exist. Falling back to elasticsearch7 [] []
 ```
 
-### Steps to reproduce:
+#### Steps to reproduce:
 
 1. Verify OpenSearch is installed.  
-2. Go to **Stores > Configuration > Catalog > Catalog Search**, and set the search engine to **OpenSearch**.
+2. Go to **Stores > Configuration > Catalog > Catalog Search**.
 3. Check the search engine. It will show Elasticsearch7.
 4. Open the `var/log/support_report.log` file and find the error message:
-**OpenSearch search engine doesn't exist. Falling back to Elasticsearch7.**
+*OpenSearch search engine doesn't exist. Falling back to Elasticsearch7.*
 
 
 
-## Cause
+### Resolution
 
-Although Adobe Commerce versions 2.4.4 and 2.4.5 support **OpenSearch**, but the application only recognizes **Elasticsearch7** as the valid **search engine** due to limitations.
+Update the `SEARCH_CONFIGURATION` variable in the `.magento.env.yaml` file, and set the search engine to *elasticsearch7*.
+
+
+#### Related articles
+- [Adobe Commerce on cloud infrastructure](https://experienceleague.adobe.com/en/docs/commerce-knowledge-base/kb/troubleshooting/miscellaneous/cannot-change-search-engine-using-magento-admin-search-engine-menu-is-inaccessible#adobe-commerce-on-cloud-infrastructure)
+- [Elasticsearch is shown as the search engine despite OpenSearch installation](https://experienceleague.adobe.com/en/docs/commerce-knowledge-base/kb/troubleshooting/elasticsearch/search-engine-shown-elasticsearch-despite-open-search)
+
+### Cause
+
+Although Adobe Commerce versions 2.4.4 and 2.4.5 support **OpenSearch**, but the application only recognizes **Elasticsearch7** as the valid search engine due to limitations.
 
 
 Starting with version 2.4.6, you can select **OpenSearch** in **Stores > Configuration > Catalog > Catalog Search** on non-cloud environments.
@@ -41,12 +50,3 @@ Starting with version 2.4.6, you can select **OpenSearch** in **Stores > Configu
 Note: In cloud environment, the search engine setting is locked in the `app/etc/env.php` file and cannot be changed.
 
 
-
-## Solution
-
-Update the `SEARCH_CONFIGURATION` variable in the `.magento.env.yaml` file, and set the **search engine** to *elasticsearch7*.
-
-
-## Related articles
-- [Adobe Commerce on cloud infrastructure](https://experienceleague.adobe.com/en/docs/commerce-knowledge-base/kb/troubleshooting/miscellaneous/cannot-change-search-engine-using-magento-admin-search-engine-menu-is-inaccessible#adobe-commerce-on-cloud-infrastructure)
-- [Elasticsearch is shown as the search engine despite OpenSearch installation](https://experienceleague.adobe.com/en/docs/commerce-knowledge-base/kb/troubleshooting/elasticsearch/search-engine-shown-elasticsearch-despite-open-search)

--- a/help/how-to/general/falling-back-to-elasticsearch7.md
+++ b/help/how-to/general/falling-back-to-elasticsearch7.md
@@ -1,1 +1,48 @@
 # Falling back to Elasticsearch7 when OpenSearch is set as the search engine in Adobe Commerce
+
+This article explains how to resolve the issue where Adobe Commerce reverts to **Elasticsearch7** when **OpenSearch** is set as the **search engine**.
+
+## Affected versions
+
+Adobe Commerce on cloud 2.4.4 - 2.4.5
+
+>**NOTE**  
+>OpenSearch is available as a search engine starting from Adobe Commerce 2.4.6.
+>
+## Issue
+
+You have set your **search engine** to **OpenSearch**, but the system shows following error in the `var/log/support_report.log` file:
+
+```
+[2024-04-04T00:27:41.212916+00:00] report.ERROR: opensearch search engine doesn't exist. Falling back to elasticsearch7 [] []
+```
+
+### Steps to reproduce:
+
+1. Verify OpenSearch is installed.  
+2. Go to **Stores > Configuration > Catalog > Catalog Search** and set the search engine to **OpenSearch**.
+3. Check the search engine. It will show Elasticsearch7.
+4. Open the `var/log/support_report.log` file and find the error message:
+**OpenSearch search engine doesn't exist. Falling back to Elasticsearch7.**
+
+
+
+## Cause
+
+Although Adobe Commerce versions 2.4.4 and 2.4.5 support **OpenSearch**, but the application only recognizes **Elasticsearch7** as the valid **search engine** due to limitations.
+
+
+Starting with version 2.4.6, you can select **OpenSearch** in **Stores > Configuration > Catalog > Catalog Search** on non-cloud environments.
+
+Note: In cloud environment, the search engine setting is locked in the `app/etc/env.php` file and cannot be changed.
+
+
+
+## Solution
+
+Update the `SEARCH_CONFIGURATION` variable in the `.magento.env.yaml` file, and set the **search engine** to *elasticsearch7*.
+
+
+## Related articles
+- [Adobe Commerce on cloud infrastructure](https://experienceleague.adobe.com/en/docs/commerce-knowledge-base/kb/troubleshooting/miscellaneous/cannot-change-search-engine-using-magento-admin-search-engine-menu-is-inaccessible#adobe-commerce-on-cloud-infrastructure)
+- [Elasticsearch is shown as the search engine despite OpenSearch installation](https://experienceleague.adobe.com/en/docs/commerce-knowledge-base/kb/troubleshooting/elasticsearch/search-engine-shown-elasticsearch-despite-open-search)

--- a/help/how-to/general/falling-back-to-elasticsearch7.md
+++ b/help/how-to/general/falling-back-to-elasticsearch7.md
@@ -20,7 +20,7 @@ You have set your **search engine** to **OpenSearch**, but the system shows foll
 ### Steps to reproduce:
 
 1. Verify OpenSearch is installed.  
-2. Go to **Stores > Configuration > Catalog > Catalog Search** and set the search engine to **OpenSearch**.
+2. Go to **Stores > Configuration > Catalog > Catalog Search**, and set the search engine to **OpenSearch**.
 3. Check the search engine. It will show Elasticsearch7.
 4. Open the `var/log/support_report.log` file and find the error message:
 **OpenSearch search engine doesn't exist. Falling back to Elasticsearch7.**

--- a/help/how-to/general/falling-back-to-elasticsearch7.md
+++ b/help/how-to/general/falling-back-to-elasticsearch7.md
@@ -23,7 +23,7 @@ You have set your search engine to **OpenSearch**, but the system shows followin
 
 #### Steps to reproduce:
 
-1. Verify OpenSearch is installed.  
+1. Verify **OpenSearch** is installed.  
 2. Go to **Stores > Configuration > Catalog > Catalog Search**.
 3. Check the search engine. It will show Elasticsearch7.
 4. Open the `var/log/support_report.log` file and find the error message:


### PR DESCRIPTION
**Title**: Falling back to Elasticsearch7 when OpenSearch is set as the search engine in Adobe Commerce.

**Purpose**:
Adds a troubleshooting article to the Adobe Commerce Knowledge Base for the interview assignment.

**Summary**:
This article provides steps to troubleshoot Adobe Commerce falling back to Elasticsearch 7 instead of using the configured OpenSearch. 

**Author Details**:
Alim Mulla